### PR TITLE
README.md: Link to micro-yuminst

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,6 @@ microdnf
 A minimal `dnf` for (mostly) Docker containers that uses
 [libhif](https://github.com/rpm-software-management/libhif)
 and hence doesn't require Python.
+
+This project was inspired by and derived from
+https://github.com/cgwalters/micro-yuminst


### PR DESCRIPTION
Since it has more rationale.  Also, we should have a link here to the
new base image in Fedora once that happens.