### PR TITLE
Fix argument parsing

### DIFF
--- a/dnf/dnf-main.c
+++ b/dnf/dnf-main.c
@@ -169,7 +169,9 @@ main (int   argc,
       if (g_strcmp0 (argv[in], "--") == 0)
         break;
       if (g_strcmp0 (argv[in], "-h") == 0 ||
-          g_strcmp0 (argv[in], "--help") == 0)
+          g_strcmp0 (argv[in], "--help") == 0 ||
+          g_strcmp0 (argv[in], "--help-all") == 0 ||
+          g_strcmp0 (argv[in], "--help-global") == 0)
         {
           show_help = TRUE;
           break;
@@ -208,6 +210,8 @@ main (int   argc,
     }
   if (cmd_name != NULL) --argc;
 
+  g_option_context_set_help_enabled (opt_ctx, TRUE);
+  
   if (cmd_name == NULL && show_help)
     {
       g_set_prgname (argv[0]);

--- a/dnf/plugins/clean/dnf-command-clean.c
+++ b/dnf/plugins/clean/dnf-command-clean.c
@@ -64,7 +64,7 @@ dnf_command_clean_run (DnfCommand      *cmd,
       return FALSE;
     }
 
-  if (g_strcmp0 (*types, "all") != 0)
+  if (g_strcmp0 (types[0], "all") != 0)
     {
       g_set_error (error,
                    G_IO_ERROR,
@@ -73,7 +73,7 @@ dnf_command_clean_run (DnfCommand      *cmd,
       return FALSE;
     }
 
-  if (*(types+1) != NULL)
+  if (types[1] != NULL)
     {
       g_set_error_literal (error,
                            G_IO_ERROR,

--- a/dnf/plugins/install/dnf-command-install.c
+++ b/dnf/plugins/install/dnf-command-install.c
@@ -68,7 +68,7 @@ dnf_command_install_run (DnfCommand      *cmd,
     }
 
   /* Install each package */
-  for (GStrv pkg = pkgs; *pkg != NULL; *pkg++)
+  for (GStrv pkg = pkgs; *pkg != NULL; pkg++)
     {
       if (!dnf_context_install (ctx, *pkg, error))
         return FALSE;

--- a/dnf/plugins/install/install.plugin
+++ b/dnf/plugins/install/install.plugin
@@ -6,4 +6,4 @@ Description = Install packages
 Authors = Richard Hughes <richard@hughsie.com>, Colin Walters <walters@verbum.org>, Igor Gnatenko <ignatenko@redhat.com>
 License = GPL-3.0+
 Copyright = Copyright © 2010-2016 Richard Hughes, Colin Walters, Igor Gnatenko
-X-Command-Syntax = install PKG [PKG...]
+X-Command-Syntax = install PACKAGE [PACKAGE…]

--- a/dnf/plugins/remove/dnf-command-remove.c
+++ b/dnf/plugins/remove/dnf-command-remove.c
@@ -66,7 +66,7 @@ dnf_command_remove_run (DnfCommand      *cmd,
     }
 
   /* Remove each package */
-  for (GStrv pkg = pkgs; *pkg != NULL; *pkg++)
+  for (GStrv pkg = pkgs; *pkg != NULL; pkg++)
     {
       if (!dnf_context_remove (ctx, *pkg, error))
         return FALSE;

--- a/dnf/plugins/remove/remove.plugin
+++ b/dnf/plugins/remove/remove.plugin
@@ -6,4 +6,4 @@ Description = Remove packages
 Authors = Igor Gnatenko <ignatenko@redhat.com>
 License = GPL-3.0+
 Copyright = Copyright © 2016 Igor Gnatenko
-X-Command-Syntax = remove PKG [PKG...]
+X-Command-Syntax = remove PACKAGE [PACKAGE…]

--- a/dnf/plugins/update/dnf-command-update.c
+++ b/dnf/plugins/update/dnf-command-update.c
@@ -64,7 +64,7 @@ dnf_command_update_run (DnfCommand      *cmd,
   else
     {
       /* Update each package */
-      for (GStrv pkg = pkgs; *pkg != NULL; *pkg++)
+      for (GStrv pkg = pkgs; *pkg != NULL; pkg++)
         {
           if (!dnf_context_update (ctx, *pkg, error))
             return FALSE;

--- a/dnf/plugins/update/update.plugin
+++ b/dnf/plugins/update/update.plugin
@@ -6,4 +6,4 @@ Description = Update packages
 Authors = Igor Gnatenko <ignatenko@redhat.com>
 License = GPL-3.0+
 Copyright = Copyright © 2016 Igor Gnatenko
-X-Command-Syntax = update [PKG…]
+X-Command-Syntax = update [PACKAGE…]


### PR DESCRIPTION
- "--option option_value" before command works now
      eg. "microdnf --disablerepo updates install package"
- "--nodocs" and "--setopt tsflags=nodocs" are honored now
- help option before command shows help for the command
      eg. "microdnf --help clean" shows help for clean command
- show help options -h and --help in global help
- change the usage help texts