### PR TITLE
do not fail on empty transactions

### DIFF
--- a/dnf/dnf-utils.c
+++ b/dnf/dnf-utils.c
@@ -2,7 +2,7 @@
  *
  * Copyright © 2010-2015 Richard Hughes <richard@hughsie.com>
  * Copyright © 2016 Colin Walters <walters@verbum.org>
- * Copyright © 2016 Igor Gnatenko <ignatenko@redhat.com>
+ * Copyright © 2016-2017 Igor Gnatenko <ignatenko@redhat.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -20,7 +20,7 @@
 
 #include "dnf-utils.h"
 
-void
+gboolean
 dnf_utils_print_transaction (DnfContext *ctx)
 {
   g_autoptr(GPtrArray) pkgs = dnf_goal_get_packages (dnf_context_get_goal (ctx),
@@ -30,16 +30,18 @@ dnf_utils_print_transaction (DnfContext *ctx)
                                                      DNF_PACKAGE_INFO_UPDATE,
                                                      DNF_PACKAGE_INFO_REMOVE,
                                                      -1);
-  g_print ("Transaction: ");
+
   if (pkgs->len == 0)
-    g_print ("(empty)");
-  else
-    g_print ("%u packages", pkgs->len);
-  g_print ("\n");
+    {
+      g_print ("Nothing to do.\n");
+      return FALSE;
+    }
+  g_print ("Transaction: %u packages\n", pkgs->len);
 
   for (guint i = 0; i < pkgs->len; i++)
     {
       DnfPackage *pkg = pkgs->pdata[i];
       g_print ("%s (%s)\n", dnf_package_get_nevra (pkg), dnf_package_get_reponame (pkg));
     }
+  return TRUE;
 }

--- a/dnf/dnf-utils.h
+++ b/dnf/dnf-utils.h
@@ -1,7 +1,7 @@
 /* dnf-utils.h
  *
  * Copyright © 2016 Colin Walters <walters@verbum.org>
- * Copyright © 2016 Igor Gnatenko <ignatenko@redhat.com>
+ * Copyright © 2016-2017 Igor Gnatenko <ignatenko@redhat.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -24,6 +24,6 @@
 
 G_BEGIN_DECLS
 
-void dnf_utils_print_transaction (DnfContext *ctx);
+gboolean dnf_utils_print_transaction (DnfContext *ctx);
 
 G_END_DECLS

--- a/dnf/plugins/install/dnf-command-install.c
+++ b/dnf/plugins/install/dnf-command-install.c
@@ -2,7 +2,7 @@
  *
  * Copyright © 2010-2015 Richard Hughes <richard@hughsie.com>
  * Copyright © 2016 Colin Walters <walters@verbum.org>
- * Copyright © 2016 Igor Gnatenko <ignatenko@redhat.com>
+ * Copyright © 2016-2017 Igor Gnatenko <ignatenko@redhat.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -75,7 +75,8 @@ dnf_command_install_run (DnfCommand      *cmd,
     }
   if (!dnf_goal_depsolve (dnf_context_get_goal (ctx), DNF_INSTALL, error))
     return FALSE;
-  dnf_utils_print_transaction (ctx);
+  if (!dnf_utils_print_transaction (ctx))
+    return TRUE;
   if (!dnf_context_run (ctx, NULL, error))
     return FALSE;
   g_print ("Complete.\n");

--- a/dnf/plugins/update/dnf-command-update.c
+++ b/dnf/plugins/update/dnf-command-update.c
@@ -1,6 +1,6 @@
 /* dnf-command-update.c
  *
- * Copyright © 2016 Igor Gnatenko <ignatenko@redhat.com>
+ * Copyright © 2016-2017 Igor Gnatenko <ignatenko@redhat.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -73,7 +73,8 @@ dnf_command_update_run (DnfCommand      *cmd,
 
   if (!dnf_goal_depsolve (dnf_context_get_goal (ctx), 0, error))
     return FALSE;
-  dnf_utils_print_transaction (ctx);
+  if (!dnf_utils_print_transaction (ctx))
+    return TRUE;
   if (!dnf_context_run (ctx, NULL, error))
     return FALSE;
   g_print ("Complete.\n");


### PR DESCRIPTION
Closes: https://github.com/rpm-software-management/microdnf/issues/3
Signed-off-by: Igor Gnatenko <ignatenko@redhat.com>



P.S. Let's hack empty transactions.. `dnf_goal_depsolve()` should return `FALSE` if goal is empty, but however it never worked (only for completely broken actions) so let's do ugly hack for checking real transaction.