### PR TITLE
Fix memory corruption during cleanup GOptionContext

### DIFF
--- a/dnf/dnf-main.c
+++ b/dnf/dnf-main.c
@@ -151,6 +151,17 @@ state_action_changed_cb (DnfState       *state,
     }
 }
 
+static GOptionGroup *
+new_global_opt_group (DnfContext *ctx)
+{
+  GOptionGroup *opt_grp = g_option_group_new ("global",
+                                              "Global Options:",
+                                              "Show global help options",
+                                              ctx,
+                                              NULL);
+  g_option_group_add_entries (opt_grp, global_opts);
+  return opt_grp;
+}
 
 int
 main (int   argc,
@@ -206,13 +217,7 @@ main (int   argc,
   g_string_free (cmd_summary, TRUE);
   g_option_context_set_ignore_unknown_options (opt_ctx, TRUE);
   g_option_context_set_help_enabled (opt_ctx, FALSE);
-  GOptionGroup *opt_global_grp = g_option_group_new ("global",
-                                                     "Global Options:",
-                                                     "Show global help options",
-                                                     ctx,
-                                                     NULL);
-  g_option_group_add_entries (opt_global_grp, global_opts);
-  g_option_context_set_main_group (opt_ctx, opt_global_grp);
+  g_option_context_set_main_group (opt_ctx, new_global_opt_group (ctx));
 
   /* Is help option in arguments? */
   for (gint in = 1; in < argc; in++)
@@ -306,7 +311,7 @@ main (int   argc,
     peas_plugin_info_get_external_data (plug, "Command-Syntax"),
     peas_plugin_info_get_description (plug));
   subcmd_opt_ctx = g_option_context_new (subcmd_opt_param);
-  g_option_context_add_group (subcmd_opt_ctx, opt_global_grp);
+  g_option_context_add_group (subcmd_opt_ctx, new_global_opt_group (ctx));
   if (!dnf_command_run (DNF_COMMAND (exten), argc, argv, subcmd_opt_ctx, ctx, &error))
     goto out;
 


### PR DESCRIPTION
The opt_global_grp was used with 2 GOptionContexts.
But both functions g_option_context_set_main_group() and
g_option_context_add_group() take ownership of passed GOptionGroup.

It can be detected using valgrind and can cause later crash.

Fix:
We create another GOptionGroup for second GOptionContext.

Valgrind output before fix:
==8252== Invalid read of size 4
==8252==    at 0x4E8F375: g_option_group_unref (in /usr/lib64/libglib-2.0.so.0.5200.3)
==8252==    by 0x4E9038E: g_option_context_free (in /usr/lib64/libglib-2.0.so.0.5200.3)
==8252==    by 0x403475: glib_autoptr_cleanup_GOptionContext (glib-autocleanups.h:62)
==8252==    by 0x40420C: main (dnf-main.c:163)
==8252==  Address 0xfe74828 is 24 bytes inside a block of size 112 free'd
==8252==    at 0x4C2FD18: free (vg_replace_malloc.c:530)
==8252==    by 0x4E8AB4D: g_free (in /usr/lib64/libglib-2.0.so.0.5200.3)
==8252==    by 0x4E815DC: g_list_foreach (in /usr/lib64/libglib-2.0.so.0.5200.3)
==8252==    by 0x4E8160A: g_list_free_full (in /usr/lib64/libglib-2.0.so.0.5200.3)
==8252==    by 0x4E90380: g_option_context_free (in /usr/lib64/libglib-2.0.so.0.5200.3)
==8252==    by 0x403475: glib_autoptr_cleanup_GOptionContext (glib-autocleanups.h:62)
==8252==    by 0x4041FD: main (dnf-main.c:164)
==8252==  Block was alloc'd at
==8252==    at 0x4C30A1E: calloc (vg_replace_malloc.c:711)
==8252==    by 0x4E8AA90: g_malloc0 (in /usr/lib64/libglib-2.0.so.0.5200.3)
==8252==    by 0x4E91E06: g_option_group_new (in /usr/lib64/libglib-2.0.so.0.5200.3)
==8252==    by 0x403C15: main (dnf-main.c:209)

