### PR TITLE
Remove call of dnf_context_set_yumdb_enabled

### DIFF
--- a/dnf/dnf-main.c
+++ b/dnf/dnf-main.c
@@ -100,7 +100,6 @@ context_new (void)
   dnf_context_set_check_transaction (ctx, TRUE);
   dnf_context_set_keep_cache (ctx, FALSE);
   dnf_context_set_cache_age (ctx, 0);
-  dnf_context_set_yumdb_enabled (ctx, FALSE);
 
   return ctx;
 }


### PR DESCRIPTION
The function was removed from libdnf-0.14.0 without replacement. There is no
yumdb support anymore. Information is stored in sqlight database.