### PR TITLE
Use help2man to generate a man page

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required (VERSION 2.8.5)
 project (microdnf C)
+set (PROJECT_VERSION 3.0.1)
 
 list (APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 
@@ -24,6 +25,25 @@ set (PKG_LIBDIR ${CMAKE_INSTALL_FULL_LIBDIR}/dnf)
 set (PKG_DATADIR ${CMAKE_INSTALL_FULL_DATADIR}/dnf)
 add_definitions (-DPACKAGE_LIBDIR="${PKG_LIBDIR}")
 add_definitions (-DPACKAGE_DATADIR="${PKG_DATADIR}")
+
+find_file (HELP2MAN_EXECUTABLE help2man)
+if (NOT HELP2MAN_EXECUTABLE)
+  message (FATAL_ERROR "unable to find help2man")
+endif ()
+
+set (MANPAGE ${CMAKE_CURRENT_BINARY_DIR}/microdnf.8)
+add_custom_command (
+  DEPENDS microdnf
+  OUTPUT ${MANPAGE}
+  COMMAND ${HELP2MAN_EXECUTABLE} $<TARGET_FILE:microdnf>
+  --version-string=${PROJECT_VERSION}
+  --no-info
+  --section=8
+  --name="Micro DNF"
+  --output=${MANPAGE}
+)
+add_custom_target (manpage ALL DEPENDS ${MANPAGE})
+install (FILES ${MANPAGE} DESTINATION ${CMAKE_INSTALL_FULL_MANDIR}/man8)
 
 include_directories (${GLIB_INCLUDE_DIRS})
 include_directories (${GOBJECT_INCLUDE_DIRS})

--- a/dnf/dnf-main.c
+++ b/dnf/dnf-main.c
@@ -210,7 +210,11 @@ main (int   argc,
       if (!peas_engine_load_plugin (engine, info))
         continue;
       if (peas_engine_provides_extension (engine, info, DNF_TYPE_COMMAND))
-        g_string_append_printf (cmd_summary, "\n  %s - %s", peas_plugin_info_get_name (info), peas_plugin_info_get_description (info));
+        /*
+         * At least 2 spaces between the command and its description are needed
+         * so that help2man formats it correctly.
+         */
+        g_string_append_printf (cmd_summary, "\n  %-16s     %s", peas_plugin_info_get_name (info), peas_plugin_info_get_description (info));
     }
   g_option_context_set_summary (opt_ctx, cmd_summary->str);
   g_string_free (cmd_summary, TRUE);

--- a/dnf/dnf-main.c
+++ b/dnf/dnf-main.c
@@ -278,7 +278,10 @@ main (int   argc,
   
   if (cmd_name == NULL && show_help)
     {
-      g_set_prgname (argv[0]);
+      const char *prg_name = strrchr(argv[0], '/') + 1;
+      prg_name = prg_name ? prg_name : argv[0];
+
+      g_set_prgname (prg_name);
       g_autofree gchar *help = g_option_context_get_help (opt_ctx, TRUE, NULL);
       g_print ("%s", help);
       goto out;

--- a/dnf/meson.build
+++ b/dnf/meson.build
@@ -40,7 +40,7 @@ microdnf_srcs = [
   'plugins/clean/dnf-command-clean.c',
 ]
 
-executable(
+microdnf = executable(
   'microdnf',
   sources : microdnf_srcs,
   dependencies : [

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('microdnf', 'c',
-        version : '1',
+        version : '3.0.1',
         license : 'GPL-3.0+',
         default_options : [
           'b_asneeded=True',
@@ -44,3 +44,22 @@ add_project_arguments(
 )
 
 subdir('dnf')
+
+help2man = find_program('help2man', required: true)
+if help2man.found()
+  help2man_opts = [
+    '--version-string=' + meson.project_version(),
+    '--no-info',
+    '--section=8',
+    '--name=Micro DNF',
+  ]
+
+  custom_target('microdnf.8',
+                output: 'microdnf.8',
+                command: [
+                  help2man, help2man_opts, '--output=@OUTPUT@', microdnf
+                ],
+                install: true,
+                install_dir: get_option('mandir') + '/man8',
+  )
+endif


### PR DESCRIPTION
Adds a .spec file copied from Fedora downstream and then adds help2man man page generation to it. A minor change was needed to the --help output so that help2man formats it correctly for the man page. The man page looks like this:
```
MICRODNF(8)                                                                                      System Administration Utilities                                                                                     MICRODNF(8)

NAME
       microdnf - Micro DNF

DESCRIPTION
   Usage:
              microdnf [OPTION?] COMMAND

   Commands:
       clean  Remove cached data

       install
              Install packages

       remove Remove packages

       update Update packages

   Help Options:
       -h, --help
              Show help options

   Application Options:
       --disablerepo=ID
              Disable repository by an id

       --enablerepo=ID
              Enable repository by an id

       --nodocs
              Install packages without docs

       --setopt=FLAG
              Set transaction flag, like tsflags=nodocs

microdnf 3.0.1                                                                                            February 2019                                                                                              MICRODNF(8)
```