### PR TITLE
Add --installroot support

### DIFF
--- a/microdnf.spec
+++ b/microdnf.spec
@@ -1,4 +1,4 @@
-%global libdnf_version 0.43.0
+%global libdnf_version 0.43.1
 
 Name:           microdnf
 Version:        3.3.0


### PR DESCRIPTION
The "--installroot" argument must be used together with "--config", "--noplugins", "--setopt=cachedir=<path>", "--setopt=reposdir=<path>", and "--setopt=varsdir=<path>" arguments.
The release version is detected from the installroot directory. If it is not possible (eg. empty/newly created installroot) then the release version must be supplied as an additional argument "--releasever=<requested_releasever>".

Fixes https://github.com/rpm-software-management/microdnf/issues/19.

Depends on https://github.com/rpm-software-management/libdnf/pull/875