### PR TITLE
Fix "microdnf --help" coredump

### DIFF
--- a/dnf/dnf-main.c
+++ b/dnf/dnf-main.c
@@ -298,8 +298,8 @@ main (int   argc,
 
   if (cmd_name == NULL && show_help)
     {
-      const char *prg_name = strrchr(argv[0], '/') + 1;
-      prg_name = prg_name ? prg_name : argv[0];
+      const char *prg_name = strrchr(argv[0], '/');
+      prg_name = prg_name ? prg_name + 1 : argv[0];
 
       g_set_prgname (prg_name);
       g_autofree gchar *help = g_option_context_get_help (opt_ctx, TRUE, NULL);


### PR DESCRIPTION
There was a bug that causes coredump during comand "microdnf --help".
The bug was in the code that removes the directory path from argv[0]
(in case argv[0] does not contain '/' character).