### PR TITLE
Add specfile

### DIFF
--- a/microdnf.spec
+++ b/microdnf.spec
@@ -1,0 +1,41 @@
+Name:           microdnf
+Version:        3.0.1
+Release:        1%{?dist}
+Summary:        Micro DNF
+
+License:        GPLv3+
+URL:            https://github.com/rpm-software-management/microdnf
+Source0:        %{url}/archive/v%{version}/%{name}-%{version}.tar.gz
+
+BuildRequires:  gcc
+BuildRequires:  meson >= 0.36.0
+BuildRequires:  pkgconfig(glib-2.0) >= 2.44.0
+BuildRequires:  pkgconfig(gobject-2.0) >= 2.44.0
+BuildRequires:  pkgconfig(libpeas-1.0) >= 1.20.0
+BuildRequires:  pkgconfig(libdnf) >= 0.7.0
+BuildRequires:  pkgconfig(smartcols)
+BuildRequires:  help2man
+
+%description
+%{summary}.
+
+%prep
+%autosetup -p1
+
+%build
+%meson
+%meson_build
+
+%install
+%meson_install
+
+%check
+%meson_test
+
+%files
+%license COPYING
+%doc README.md
+%{_mandir}/man8/microdnf.8*
+%{_bindir}/%{name}
+
+%changelog


### PR DESCRIPTION
All rpm-software-management package repositories have specfiles in
upstream this unifies microdnf with them.
It also currently enables building of microdnf in dnf-nightly copr because
we cannot yet use downstream specfile since it is missing new help2man
dependency