### PR TITLE
Fix: do not download metadata in remove command

### DIFF
--- a/dnf/plugins/remove/dnf-command-remove.c
+++ b/dnf/plugins/remove/dnf-command-remove.c
@@ -38,6 +38,17 @@ dnf_command_remove_init (DnfCommandRemove *self)
 {
 }
 
+static void
+disable_available_repos (DnfContext *ctx)
+{
+  GPtrArray *repos = dnf_context_get_repos (ctx);
+  for (guint i = 0; i < repos->len; ++i)
+    {
+      DnfRepo * repo = g_ptr_array_index (repos, i);
+      dnf_repo_set_enabled (repo, DNF_REPO_ENABLED_NONE);
+    }
+}
+
 static gboolean
 dnf_command_remove_run (DnfCommand      *cmd,
                          int              argc,
@@ -64,6 +75,8 @@ dnf_command_remove_run (DnfCommand      *cmd,
                            "Packages are not specified");
       return FALSE;
     }
+
+  disable_available_repos (ctx);
 
   /* Remove each package */
   for (GStrv pkg = pkgs; *pkg != NULL; pkg++)


### PR DESCRIPTION
Microdnf downloades repository metadata in the remove command. It is
not needed because the remove command does not use them. In addition,
there is a problem with unavailable repositories when
skip_if_unavailable=false. In this case, microdnf stops with error
message "error: cannot update repo ..." and does not remove any package.

The fix disables loading of repository metadata in the remove command.