### PR TITLE
update README to reflect libhif→dnf

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ microdnf
 ========
 
 A minimal `dnf` for (mostly) Docker containers that uses
-[libhif](https://github.com/rpm-software-management/libhif)
+[libdnf](https://github.com/rpm-software-management/libdnf)
 and hence doesn't require Python.
 
 This project was inspired by and derived from


### PR DESCRIPTION
libhif no longer exists and microdnf uses libdnf