### PR TITLE
[spec] Bump libdnf require (RhBug:1771611)

### DIFF
--- a/microdnf.spec
+++ b/microdnf.spec
@@ -12,7 +12,7 @@ BuildRequires:  meson >= 0.36.0
 BuildRequires:  pkgconfig(glib-2.0) >= 2.44.0
 BuildRequires:  pkgconfig(gobject-2.0) >= 2.44.0
 BuildRequires:  pkgconfig(libpeas-1.0) >= 1.20.0
-BuildRequires:  pkgconfig(libdnf) >= 0.37.1
+BuildRequires:  pkgconfig(libdnf) >= 0.37.2
 BuildRequires:  pkgconfig(smartcols)
 BuildRequires:  help2man
 


### PR DESCRIPTION
microdnf PR: https://github.com/rpm-software-management/microdnf/pull/52 requires libdnf PR: https://github.com/rpm-software-management/libdnf/pull/826 however this libdnf PR is present in version 0.37.2, where as microdnf currently requires only 0.37.1

https://bugzilla.redhat.com/show_bug.cgi?id=1771611