### PR TITLE
Support "install_weak_deps" conf option and "--setopt=install_weak_deps=0/1"

### DIFF
--- a/dnf/plugins/install/dnf-command-install.c
+++ b/dnf/plugins/install/dnf-command-install.c
@@ -78,6 +78,8 @@ dnf_command_install_run (DnfCommand      *cmd,
     {
       flags |= DNF_FORCE_BEST;
     }
+  if (!dnf_context_get_install_weak_deps ())
+    flags |= DNF_IGNORE_WEAK_DEPS;  
   if (!dnf_goal_depsolve (dnf_context_get_goal (ctx), flags, error))
     return FALSE;
   if (!dnf_utils_print_transaction (ctx))

--- a/dnf/plugins/reinstall/dnf-command-reinstall.c
+++ b/dnf/plugins/reinstall/dnf-command-reinstall.c
@@ -149,6 +149,8 @@ dnf_command_reinstall_run (DnfCommand      *cmd,
     }
 
   DnfGoalActions flags = DNF_INSTALL;
+  if (!dnf_context_get_install_weak_deps ())
+    flags |= DNF_IGNORE_WEAK_DEPS;  
   if (!dnf_goal_depsolve (dnf_context_get_goal (ctx), flags, error))
     return FALSE;
   

--- a/dnf/plugins/update/dnf-command-update.c
+++ b/dnf/plugins/update/dnf-command-update.c
@@ -75,6 +75,8 @@ dnf_command_update_run (DnfCommand      *cmd,
     {
       flags |= DNF_FORCE_BEST;
     }
+  if (!dnf_context_get_install_weak_deps ())
+    flags |= DNF_IGNORE_WEAK_DEPS;  
   if (!dnf_goal_depsolve (dnf_context_get_goal (ctx), flags, error))
     return FALSE;
   if (!dnf_utils_print_transaction (ctx))

--- a/microdnf.spec
+++ b/microdnf.spec
@@ -1,4 +1,4 @@
-%global libdnf_version 0.38.0
+%global libdnf_version 0.40.0
 
 Name:           microdnf
 Version:        3.3.0


### PR DESCRIPTION
The microdnf allways instaled weak dependencies. But it is usually used in containers. And in a lot of cases user want minimal installation (minimal container size) without weak dependencies.
So, the patch adds support for disabling weak dependencies.

depends on: https://github.com/rpm-software-management/libdnf/pull/862
and merge after: https://github.com/rpm-software-management/microdnf/pull/61 