### PR TITLE
Add "--setopt=tsflags=test" support

### DIFF
--- a/dnf/dnf-main.c
+++ b/dnf/dnf-main.c
@@ -70,15 +70,20 @@ process_global_option (const gchar  *option_name,
         }
       else if (strcmp (setopt[0], "tsflags") == 0)
         {
-          if (strcmp (setopt[1], "nodocs") == 0)
-            opt_nodocs = TRUE;
-          else if (strcmp (setopt[1], "test") == 0)
-            opt_test = TRUE;
-          else 
+          g_auto(GStrv) tsflags = g_strsplit (setopt[1], ",", -1);
+          for (char **it = tsflags; *it; ++it)
             {
-              local_error = g_error_new (G_OPTION_ERROR, G_OPTION_ERROR_BAD_VALUE,
-                                        "Unknown tsflag: %s", setopt[1]);
-              ret = FALSE;
+              if (strcmp (*it, "nodocs") == 0)
+                opt_nodocs = TRUE;
+              else if (strcmp (*it, "test") == 0)
+                opt_test = TRUE;
+              else
+                {
+                  local_error = g_error_new (G_OPTION_ERROR, G_OPTION_ERROR_BAD_VALUE,
+                                            "Unknown tsflag: %s", *it);
+                  ret = FALSE;
+                  break;
+                }
             }
         }
       else if (strcmp (setopt[0], "install_weak_deps") == 0)

--- a/dnf/dnf-utils.c
+++ b/dnf/dnf-utils.c
@@ -147,5 +147,10 @@ dnf_utils_print_transaction (DnfContext *ctx)
   g_print (" %-15s %4d packages\n", "Removing:", pkgs_remove->len);
   g_print (" %-15s %4d packages\n", "Downgrading:", pkgs_downgrade->len);
 
+  /* check for test mode */
+  DnfTransaction *txn = dnf_context_get_transaction (ctx);
+  if (dnf_transaction_get_flags (txn) & DNF_TRANSACTION_FLAG_TEST)
+    g_print ("Test mode enabled: Microdnf will only download packages, install gpg keys, and check the transaction.\n");
+
   return TRUE;
 }

--- a/dnf/plugins/reinstall/dnf-command-reinstall.c
+++ b/dnf/plugins/reinstall/dnf-command-reinstall.c
@@ -154,8 +154,9 @@ dnf_command_reinstall_run (DnfCommand      *cmd,
   if (!dnf_goal_depsolve (dnf_context_get_goal (ctx), flags, error))
     return FALSE;
   
-  DnfTransaction *transaction = dnf_context_get_transaction(ctx);
-  dnf_transaction_set_flags(transaction, DNF_TRANSACTION_FLAG_ALLOW_REINSTALL);
+  DnfTransaction *transaction = dnf_context_get_transaction (ctx);
+  int tsflags = dnf_transaction_get_flags (transaction);
+  dnf_transaction_set_flags(transaction, tsflags | DNF_TRANSACTION_FLAG_ALLOW_REINSTALL);
 
   if (!dnf_utils_print_transaction (ctx))
     return TRUE;


### PR DESCRIPTION
There was no possibility only to show and test a transaction. The transaction was always performed.
The `test` option provides a transaction check without performing  the transaction. It includes downloading of packages, gpg keys check (including permanent import of additional keys if necessary), and rpm check to prevent file conflicts.

Merge after this: https://github.com/rpm-software-management/microdnf/pull/62