### PR TITLE
Fix --setopt=install_weak_deps=0

### DIFF
--- a/dnf/dnf-main.c
+++ b/dnf/dnf-main.c
@@ -339,6 +339,10 @@ main (int   argc,
       if (opt_test)
         flags |= DNF_TRANSACTION_FLAG_TEST;
       dnf_transaction_set_flags (txn, flags);
+      
+      /* Disable calling dnf_goal_depsolve() during dnf_context_run().
+       * The calling is done with hardcoded parameters. We dont want it. */
+      dnf_transaction_set_dont_solve_goal(txn, TRUE);
 
       if (opt_best && opt_nobest)
         {

--- a/microdnf.spec
+++ b/microdnf.spec
@@ -1,4 +1,4 @@
-%global libdnf_version 0.40.0
+%global libdnf_version 0.42.0
 
 Name:           microdnf
 Version:        3.3.0


### PR DESCRIPTION
There was a bug. Solved transaction was always resolved again with hardcoded parameters (and weak dependencies was always installed).

The patch needs `libdnf with dnf_transaction_set_dont_solve_goal()` function.
Depends on https://github.com/rpm-software-management/libdnf/pull/868

Example of bug (weak deps transaction is resolved and 3 instead 2 packages are installed):
```
# microdnf install --setopt=install_weak_deps=0 abcde
Package                        Repository            Size
Installing:
 abcde-2.9.2-1.fc29.noarch      dnf-ci-fedora      6.20 kB
 wget-1.19.5-5.fc29.x86_64      dnf-ci-fedora      6.50 kB
Transaction Summary:
 Installing:        2 packages
 Reinstalling:      0 packages
 Upgrading:         0 packages
 Removing:          0 packages
 Downgrading:       0 packages
Running transaction test...
Installing: wget;1.19.5-5.fc29;x86_64;dnf-ci-fedora
Installing: flac;1.3.2-8.fc29;x86_64;dnf-ci-fedora
Installing: abcde;2.9.2-1.fc29;noarch;dnf-ci-fedora
Complete.
```