### PR TITLE
Respect reposdir from conf file, support multiple repos dirs in "--setopt=reposdir="

### DIFF
--- a/dnf/dnf-main.c
+++ b/dnf/dnf-main.c
@@ -147,7 +147,6 @@ context_new (void)
 {
   DnfContext *ctx = dnf_context_new ();
 
-  dnf_context_set_repo_dir (ctx, "/etc/yum.repos.d/");
 #define CACHEDIR "/var/cache/yum"
   dnf_context_set_cache_dir (ctx, CACHEDIR"/metadata");
   dnf_context_set_solv_dir (ctx, CACHEDIR"/solv");

--- a/dnf/dnf-main.c
+++ b/dnf/dnf-main.c
@@ -102,7 +102,8 @@ process_global_option (const gchar  *option_name,
         }
       else if (strcmp (setopt[0], "reposdir") == 0)
         {
-          dnf_context_set_repo_dir (ctx, setopt[1]);
+          g_auto(GStrv) reposdir = g_strsplit (setopt[1], ",", -1);
+          dnf_context_set_repos_dir (ctx, (const gchar * const *)reposdir);
         }
       else if (strcmp (setopt[0], "varsdir") == 0)
         {
@@ -138,7 +139,7 @@ static const GOptionEntry global_opts[] = {
   { "nodocs", '\0', G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE, &opt_nodocs, "Install packages without docs", NULL },
   { "releasever", '\0', G_OPTION_FLAG_NONE, G_OPTION_ARG_CALLBACK, process_global_option, "Override the value of $releasever in config and repo files", "RELEASEVER" },
   { "setopt", '\0', G_OPTION_FLAG_NONE, G_OPTION_ARG_CALLBACK, process_global_option,
-    "Override a configuration option (install_weak_deps=0/1, reposdir=<path>, tsflags=nodocs/test, varsdir=<path1>,<path2>,...)", "<option>=<value>" },
+    "Override a configuration option (install_weak_deps=0/1, reposdir=<path1>,<path2>,..., tsflags=nodocs/test, varsdir=<path1>,<path2>,...)", "<option>=<value>" },
   { NULL }
 };
 


### PR DESCRIPTION
* The old libdnf version required setting of path to repository. The new libdnf reads the path from configuration file. Or sets the default path if it is not found in the configuration file.
So, the PR removes default setting of path to repository from the microdnf.

* PR allows to set multiple repos directories by --setopt.
Format: `--setopt=reposdir=<path1>, <path2>,...`
    
Needs libdnf with support for reposdir in configuration file and with `dnf_context_set_repos_dir()` function.
Depends on: https://github.com/rpm-software-management/libdnf/pull/868