### PR TITLE
Respect "metadata_expire" conf file opton, add "--refresh" (RhBug:1771147)

### DIFF
--- a/dnf/dnf-main.c
+++ b/dnf/dnf-main.c
@@ -35,6 +35,7 @@ static gboolean opt_nodocs = FALSE;
 static gboolean opt_best = FALSE;
 static gboolean opt_nobest = FALSE;
 static gboolean opt_test = FALSE;
+static gboolean opt_refresh = FALSE;
 static gboolean show_help = FALSE;
 static gboolean dl_pkgs_printed = FALSE;
 static GSList *enable_disable_repos = NULL;
@@ -208,6 +209,7 @@ static const GOptionEntry global_opts[] = {
   { "installroot", '\0', G_OPTION_FLAG_NONE, G_OPTION_ARG_CALLBACK, process_global_option, "Set install root", "PATH" },
   { "nodocs", '\0', G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE, &opt_nodocs, "Install packages without docs", NULL },
   { "noplugins", '\0', G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE, &disable_plugins_loading, "Disable loading of plugins", NULL },
+  { "refresh", '\0', G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE, &opt_refresh, "Set metadata as expired before running the command", NULL },
   { "releasever", '\0', G_OPTION_FLAG_NONE, G_OPTION_ARG_CALLBACK, process_global_option, "Override the value of $releasever in config and repo files", "RELEASEVER" },
   { "setopt", '\0', G_OPTION_FLAG_NONE, G_OPTION_ARG_CALLBACK, process_global_option,
     "Override a configuration option (install_weak_deps=0/1, cachedir=<path>, reposdir=<path1>,<path2>,..., tsflags=nodocs/test, varsdir=<path1>,<path2>,...)", "<option>=<value>" },
@@ -411,6 +413,9 @@ main (int   argc,
             g_print ("Loading of plugins is disabled by configuration file. "
                      "Use of \"--enableplugin\" and \"--disableplugin\" has no meaning.\n");
         }
+
+      if (opt_refresh)
+       dnf_context_set_cache_age (ctx, 0);
 
       if (!dnf_context_setup (ctx, NULL, &error))
         goto out;

--- a/dnf/dnf-main.c
+++ b/dnf/dnf-main.c
@@ -227,7 +227,13 @@ context_new (void)
   dnf_context_set_check_disk_space (ctx, FALSE);
   dnf_context_set_check_transaction (ctx, TRUE);
   dnf_context_set_keep_cache (ctx, FALSE);
-  dnf_context_set_cache_age (ctx, 0);
+
+  /* Sets a maximum cache age in seconds. It is an upper limit.
+   * The lower value between this value and "metadata_expire" value from repo/global
+   * configuration file is used.
+   * The value G_MAXUINT has a special meaning. It means that the cache never expires
+   * regardless of the settings in the configuration files. */
+  dnf_context_set_cache_age (ctx, G_MAXUINT - 1); 
 
   return ctx;
 }

--- a/microdnf.spec
+++ b/microdnf.spec
@@ -1,7 +1,7 @@
 %global libdnf_version 0.43.1
 
 Name:           microdnf
-Version:        3.3.0
+Version:        3.4.0
 Release:        1%{?dist}
 Summary:        Minimal C implementation of DNF
 


### PR DESCRIPTION
Description of solved problem:
Microdnf always downloaded metadata.  Again and again during each actions. It was annoying. It took time and wastly downloaded data. There is metadata_expire" option in repository and global configuration file but microdnf ignored it.
The problem was more annoying with subcommand `repoquery`. Everytime when `repoquery` was used for search in available metadata the metadata are be again downloaded.

New behaviour of microdnf is similar to DNF. It respects `metadata_expire` config files option. And program argument `--refresh` can be used to set metadata as expired before running the command.
 So, with `--refresh` we get previous behaviour of microdnf.