### PR TITLE
Add subcommands support and "module enable" skeleton

### DIFF
--- a/dnf/CMakeLists.txt
+++ b/dnf/CMakeLists.txt
@@ -35,6 +35,12 @@ glib_compile_resources (DNF_COMMAND_CLEAN plugins/clean/dnf-command-clean.gresou
                         INTERNAL)
 list (APPEND DNF_COMMAND_CLEAN "plugins/clean/dnf-command-clean.c")
 
+glib_compile_resources (DNF_COMMAND_MODULE_ENABLE plugins/module_enable/dnf-command-module_enable.gresource.xml
+                        C_PREFIX dnf_command_module_enable
+                        INTERNAL)
+list (APPEND DNF_COMMAND_MODULE_ENABLE "plugins/module_enable/dnf-command-module_enable.c")
+
+
 include_directories (${CMAKE_CURRENT_SOURCE_DIR})
 add_executable (microdnf dnf-main.c ${DNF_SRCS}
                 ${DNF_COMMAND_INSTALL}
@@ -43,7 +49,8 @@ add_executable (microdnf dnf-main.c ${DNF_SRCS}
                 ${DNF_COMMAND_UPDATE}
                 ${DNF_COMMAND_REPOLIST}
                 ${DNF_COMMAND_REPOQUERY}
-                ${DNF_COMMAND_CLEAN})
+                ${DNF_COMMAND_CLEAN}
+                ${DNF_COMMAND_MODULE_ENABLE})
 
 target_link_libraries (microdnf
                        ${GLIB_LIBRARIES}

--- a/dnf/meson.build
+++ b/dnf/meson.build
@@ -65,6 +65,15 @@ microdnf_srcs = [
     source_dir : 'plugins/clean',
   ),
   'plugins/clean/dnf-command-clean.c',
+
+  # module enable
+  gnome.compile_resources(
+    'dnf-module_enable',
+    'plugins/module_enable/dnf-command-module_enable.gresource.xml',
+    c_name : 'dnf_command_module_enable',
+    source_dir : 'plugins/module_enable',
+  ),
+  'plugins/module_enable/dnf-command-module_enable.c',
 ]
 
 microdnf = executable(

--- a/dnf/plugins/module_enable/dnf-command-module_enable.c
+++ b/dnf/plugins/module_enable/dnf-command-module_enable.c
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2020 Red Hat, Inc.
+ *
+ * Licensed under the GNU Lesser General Public License Version 2.1
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include "dnf-command-module_enable.h"
+#include "dnf-utils.h"
+
+struct _DnfCommandModuleEnable
+{
+  PeasExtensionBase parent_instance;
+};
+
+static void dnf_command_module_enable_iface_init (DnfCommandInterface *iface);
+
+G_DEFINE_DYNAMIC_TYPE_EXTENDED (DnfCommandModuleEnable,
+                                dnf_command_module_enable,
+                                PEAS_TYPE_EXTENSION_BASE,
+                                0,
+                                G_IMPLEMENT_INTERFACE (DNF_TYPE_COMMAND,
+                                                       dnf_command_module_enable_iface_init))
+
+static void
+dnf_command_module_enable_init (DnfCommandModuleEnable *self)
+{
+}
+
+static gboolean
+dnf_command_module_enable_run (DnfCommand      *cmd,
+                               int              argc,
+                               char            *argv[],
+                               GOptionContext  *opt_ctx,
+                               DnfContext      *ctx,
+                               GError         **error)
+{
+  g_auto(GStrv) pkgs = NULL;
+  const GOptionEntry opts[] = {
+    { G_OPTION_REMAINING, '\0', 0, G_OPTION_ARG_STRING_ARRAY, &pkgs, NULL, NULL },
+    { NULL }
+  };
+  g_option_context_add_main_entries (opt_ctx, opts, NULL);
+
+  if (!g_option_context_parse (opt_ctx, &argc, &argv, error))
+    return FALSE;
+
+  if (pkgs == NULL)
+    {
+      g_set_error_literal (error,
+                           G_IO_ERROR,
+                           G_IO_ERROR_FAILED,
+                           "Modules are not specified");
+      return FALSE;
+    }
+
+    return dnf_context_enable_modules (ctx, (const char **)pkgs, error);
+}
+
+static void
+dnf_command_module_enable_class_init (DnfCommandModuleEnableClass *klass)
+{
+}
+
+static void
+dnf_command_module_enable_iface_init (DnfCommandInterface *iface)
+{
+  iface->run = dnf_command_module_enable_run;
+}
+
+static void
+dnf_command_module_enable_class_finalize (DnfCommandModuleEnableClass *klass)
+{
+}
+
+G_MODULE_EXPORT void
+dnf_command_module_enable_register_types (PeasObjectModule *module)
+{
+  dnf_command_module_enable_register_type (G_TYPE_MODULE (module));
+
+  peas_object_module_register_extension_type (module,
+                                              DNF_TYPE_COMMAND,
+                                              DNF_TYPE_COMMAND_MODULE_ENABLE);
+}

--- a/dnf/plugins/module_enable/dnf-command-module_enable.gresource.xml
+++ b/dnf/plugins/module_enable/dnf-command-module_enable.gresource.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gresources>
+  <gresource prefix="/org/fedoraproject/dnf/plugins/module_enable">
+    <file>module_enable.plugin</file>
+  </gresource>
+</gresources>

--- a/dnf/plugins/module_enable/dnf-command-module_enable.h
+++ b/dnf/plugins/module_enable/dnf-command-module_enable.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2020 Red Hat, Inc.
+ *
+ * Licensed under the GNU Lesser General Public License Version 2.1
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#pragma once
+
+#include "dnf-command.h"
+#include <libpeas/peas.h>
+
+G_BEGIN_DECLS
+
+#define DNF_TYPE_COMMAND_MODULE_ENABLE dnf_command_module_enable_get_type ()
+G_DECLARE_FINAL_TYPE (DnfCommandModuleEnable, dnf_command_module_enable, DNF, COMMAND_MODULE_ENABLE, PeasExtensionBase)
+
+G_MODULE_EXPORT void dnf_command_module_enable_register_types (PeasObjectModule *module);
+
+G_END_DECLS

--- a/dnf/plugins/module_enable/module_enable.plugin
+++ b/dnf/plugins/module_enable/module_enable.plugin
@@ -1,0 +1,9 @@
+[Plugin]
+Module = command_module_enable
+Embedded = dnf_command_module_enable_register_types
+Name = module_enable
+Description = Enable a module stream
+Authors = Jaroslav Rohel <jrohel@redhat.com>
+License = GPL-3.0+
+Copyright = Copyright (C) 2020 Red Hat, Inc.
+X-Command-Syntax = module enable module-spec [module-spec…]

--- a/microdnf.spec
+++ b/microdnf.spec
@@ -1,4 +1,4 @@
-%global libdnf_version 0.43.1
+%global libdnf_version 0.55.0
 
 Name:           microdnf
 Version:        3.4.0


### PR DESCRIPTION
- Added subcommands support
  Plugins with a '_' character in command name will  implement subcommands.
  Needed for modularity subcommands.
  E.g. the `command_module_enable` plugin will implement the `enable` subcommand of the `module` command.

- Added `module enable` command.

Depends on: https://github.com/rpm-software-management/libdnf/pull/1072