### PR TITLE
Bump minimum version of libdnf in CMake and Meson

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ find_package (PkgConfig REQUIRED)
 pkg_check_modules (GLIB REQUIRED glib-2.0>=2.44.0)
 pkg_check_modules (GOBJECT REQUIRED gobject-2.0>=2.44.0)
 pkg_check_modules (PEAS REQUIRED libpeas-1.0>=1.20.0)
-pkg_check_modules (LIBDNF REQUIRED libdnf>=0.7.0)
+pkg_check_modules (LIBDNF REQUIRED libdnf>=0.55.0)
 pkg_check_modules (SCOLS REQUIRED smartcols)
 
 set (PKG_LIBDIR ${CMAKE_INSTALL_FULL_LIBDIR}/dnf)

--- a/meson.build
+++ b/meson.build
@@ -32,7 +32,7 @@ gnome = import('gnome')
 glib = dependency('glib-2.0', version : '>=2.44.0')
 gobject = dependency('gobject-2.0', version : '>=2.44.0')
 libpeas = dependency('libpeas-1.0', version : '>=1.20.0')
-libdnf = dependency('libdnf', version : '>=0.7.0')
+libdnf = dependency('libdnf', version : '>=0.55.0')
 scols = dependency('smartcols')
 
 pkg_libdir = join_paths(get_option('prefix'), get_option('libdir'), 'dnf')


### PR DESCRIPTION
This was supposed to be done in 1a11b81885b4ca3b7493b158984687d9cba81017,
but it was missed by accident.