### PR TITLE
Add dependency for DNF configurations skeleton

### DIFF
--- a/microdnf.spec
+++ b/microdnf.spec
@@ -19,6 +19,8 @@ BuildRequires:  pkgconfig(smartcols)
 BuildRequires:  help2man
 
 Requires:       libdnf%{?_isa} >= %{libdnf_version}
+# Ensure DNF package manager configuration skeleton is installed
+Requires:       dnf-data
 
 %description
 Micro DNF is a very minimal C implementation of DNF's install, upgrade,


### PR DESCRIPTION
Micro DNF uses the same configuration skeleton as DNF, and can fail
if it's missing.