### PR TITLE
dnf-data requirement only for Fedora and future RHEL

### DIFF
--- a/microdnf.spec
+++ b/microdnf.spec
@@ -19,8 +19,10 @@ BuildRequires:  pkgconfig(smartcols)
 BuildRequires:  help2man
 
 Requires:       libdnf%{?_isa} >= %{libdnf_version}
+%if 0%{?rhel} > 8 || 0%{?fedora}
 # Ensure DNF package manager configuration skeleton is installed
 Requires:       dnf-data
+%endif
 
 %description
 Micro DNF is a very minimal C implementation of DNF's install, upgrade,


### PR DESCRIPTION
Do not change dependencies during RHEL 8 life cycle.