### PR TITLE
Rename "update" command to "upgrade", "update" remain as compatibility alias

### DIFF
--- a/dnf/CMakeLists.txt
+++ b/dnf/CMakeLists.txt
@@ -15,10 +15,10 @@ glib_compile_resources (DNF_COMMAND_REMOVE plugins/remove/dnf-command-remove.gre
                         INTERNAL)
 list (APPEND DNF_COMMAND_REMOVE "plugins/remove/dnf-command-remove.c")
 
-glib_compile_resources (DNF_COMMAND_UPDATE plugins/update/dnf-command-update.gresource.xml
-                        C_PREFIX dnf_command_update
+glib_compile_resources (DNF_COMMAND_UPGRADE plugins/upgrade/dnf-command-upgrade.gresource.xml
+                        C_PREFIX dnf_command_upgrade
                         INTERNAL)
-list (APPEND DNF_COMMAND_UPDATE "plugins/update/dnf-command-update.c")
+list (APPEND DNF_COMMAND_UPGRADE "plugins/upgrade/dnf-command-upgrade.c")
 
 glib_compile_resources (DNF_COMMAND_REPOLIST plugins/repolist/dnf-command-repolist.gresource.xml
                         C_PREFIX dnf_command_repolist
@@ -56,7 +56,7 @@ add_executable (microdnf dnf-main.c ${DNF_SRCS}
                 ${DNF_COMMAND_INSTALL}
                 ${DNF_COMMAND_REINSTALL}
                 ${DNF_COMMAND_REMOVE}
-                ${DNF_COMMAND_UPDATE}
+                ${DNF_COMMAND_UPGRADE}
                 ${DNF_COMMAND_REPOLIST}
                 ${DNF_COMMAND_REPOQUERY}
                 ${DNF_COMMAND_CLEAN}

--- a/dnf/meson.build
+++ b/dnf/meson.build
@@ -30,14 +30,14 @@ microdnf_srcs = [
   ),
   'plugins/remove/dnf-command-remove.c',
 
-  # update
+  # upgrade
   gnome.compile_resources(
-    'dnf-update',
-    'plugins/update/dnf-command-update.gresource.xml',
-    c_name : 'dnf_command_update',
-    source_dir : 'plugins/update',
+    'dnf-upgrade',
+    'plugins/upgrade/dnf-command-upgrade.gresource.xml',
+    c_name : 'dnf_command_upgrade',
+    source_dir : 'plugins/upgrade',
   ),
-  'plugins/update/dnf-command-update.c',
+  'plugins/upgrade/dnf-command-upgrade.c',
 
   # repolist
   gnome.compile_resources(

--- a/dnf/plugins/update/dnf-command-update.gresource.xml
+++ b/dnf/plugins/update/dnf-command-update.gresource.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<gresources>
-  <gresource prefix="/org/fedoraproject/dnf/plugins/update">
-    <file>update.plugin</file>
-  </gresource>
-</gresources>

--- a/dnf/plugins/update/update.plugin
+++ b/dnf/plugins/update/update.plugin
@@ -1,9 +1,0 @@
-[Plugin]
-Module = command_update
-Embedded = dnf_command_update_register_types
-Name = update
-Description = Update packages
-Authors = Igor Gnatenko <ignatenko@redhat.com>
-License = GPL-2.0+
-Copyright = Copyright © 2016 Igor Gnatenko
-X-Command-Syntax = update [PACKAGE…]

--- a/dnf/plugins/upgrade/dnf-command-upgrade.c
+++ b/dnf/plugins/upgrade/dnf-command-upgrade.c
@@ -1,4 +1,4 @@
-/* dnf-command-update.c
+/* dnf-command-upgrade.c
  *
  * Copyright © 2016-2017 Igor Gnatenko <ignatenko@redhat.com>
  *
@@ -16,35 +16,35 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "dnf-command-update.h"
+#include "dnf-command-upgrade.h"
 #include "dnf-utils.h"
 
-struct _DnfCommandUpdate
+struct _DnfCommandUpgrade
 {
   PeasExtensionBase parent_instance;
 };
 
-static void dnf_command_update_iface_init (DnfCommandInterface *iface);
+static void dnf_command_upgrade_iface_init (DnfCommandInterface *iface);
 
-G_DEFINE_DYNAMIC_TYPE_EXTENDED (DnfCommandUpdate,
-                                dnf_command_update,
+G_DEFINE_DYNAMIC_TYPE_EXTENDED (DnfCommandUpgrade,
+                                dnf_command_upgrade,
                                 PEAS_TYPE_EXTENSION_BASE,
                                 0,
                                 G_IMPLEMENT_INTERFACE (DNF_TYPE_COMMAND,
-                                                       dnf_command_update_iface_init))
+                                                       dnf_command_upgrade_iface_init))
 
 static void
-dnf_command_update_init (DnfCommandUpdate *self)
+dnf_command_upgrade_init (DnfCommandUpgrade *self)
 {
 }
 
 static gboolean
-dnf_command_update_run (DnfCommand      *cmd,
-                        int              argc,
-                        char            *argv[],
-                        GOptionContext  *opt_ctx,
-                        DnfContext      *ctx,
-                        GError         **error)
+dnf_command_upgrade_run (DnfCommand      *cmd,
+                         int              argc,
+                         char            *argv[],
+                         GOptionContext  *opt_ctx,
+                         DnfContext      *ctx,
+                         GError         **error)
 {
   g_auto(GStrv) pkgs = NULL;
   const GOptionEntry opts[] = {
@@ -63,7 +63,7 @@ dnf_command_update_run (DnfCommand      *cmd,
     }
   else
     {
-      /* Update each package */
+      /* Upgrade each package */
       for (GStrv pkg = pkgs; *pkg != NULL; pkg++)
         {
           if (!dnf_context_update (ctx, *pkg, error))
@@ -89,27 +89,27 @@ dnf_command_update_run (DnfCommand      *cmd,
 }
 
 static void
-dnf_command_update_class_init (DnfCommandUpdateClass *klass)
+dnf_command_upgrade_class_init (DnfCommandUpgradeClass *klass)
 {
 }
 
 static void
-dnf_command_update_iface_init (DnfCommandInterface *iface)
+dnf_command_upgrade_iface_init (DnfCommandInterface *iface)
 {
-  iface->run = dnf_command_update_run;
+  iface->run = dnf_command_upgrade_run;
 }
 
 static void
-dnf_command_update_class_finalize (DnfCommandUpdateClass *klass)
+dnf_command_upgrade_class_finalize (DnfCommandUpgradeClass *klass)
 {
 }
 
 G_MODULE_EXPORT void
-dnf_command_update_register_types (PeasObjectModule *module)
+dnf_command_upgrade_register_types (PeasObjectModule *module)
 {
-  dnf_command_update_register_type (G_TYPE_MODULE (module));
+  dnf_command_upgrade_register_type (G_TYPE_MODULE (module));
 
   peas_object_module_register_extension_type (module,
                                               DNF_TYPE_COMMAND,
-                                              DNF_TYPE_COMMAND_UPDATE);
+                                              DNF_TYPE_COMMAND_UPGRADE);
 }

--- a/dnf/plugins/upgrade/dnf-command-upgrade.gresource.xml
+++ b/dnf/plugins/upgrade/dnf-command-upgrade.gresource.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gresources>
+  <gresource prefix="/org/fedoraproject/dnf/plugins/upgrade">
+    <file>upgrade.plugin</file>
+  </gresource>
+</gresources>

--- a/dnf/plugins/upgrade/dnf-command-upgrade.h
+++ b/dnf/plugins/upgrade/dnf-command-upgrade.h
@@ -1,4 +1,4 @@
-/* dnf-command-update.h
+/* dnf-command-upgrade.h
  *
  * Copyright © 2016 Igor Gnatenko <ignatenko@redhat.com>
  *
@@ -23,9 +23,9 @@
 
 G_BEGIN_DECLS
 
-#define DNF_TYPE_COMMAND_UPDATE dnf_command_update_get_type ()
-G_DECLARE_FINAL_TYPE (DnfCommandUpdate, dnf_command_update, DNF, COMMAND_UPDATE, PeasExtensionBase)
+#define DNF_TYPE_COMMAND_UPGRADE dnf_command_upgrade_get_type ()
+G_DECLARE_FINAL_TYPE (DnfCommandUpgrade, dnf_command_upgrade, DNF, COMMAND_UPGRADE, PeasExtensionBase)
 
-G_MODULE_EXPORT void dnf_command_update_register_types (PeasObjectModule *module);
+G_MODULE_EXPORT void dnf_command_upgrade_register_types (PeasObjectModule *module);
 
 G_END_DECLS

--- a/dnf/plugins/upgrade/upgrade.plugin
+++ b/dnf/plugins/upgrade/upgrade.plugin
@@ -1,0 +1,9 @@
+[Plugin]
+Module = command_upgrade
+Embedded = dnf_command_upgrade_register_types
+Name = upgrade
+Description = Upgrade packages
+Authors = Igor Gnatenko <ignatenko@redhat.com>
+License = GPL-2.0+
+Copyright = Copyright © 2016 Igor Gnatenko
+X-Command-Syntax = upgrade [PACKAGE…]

--- a/dnf/plugins/upgrade/upgrade.plugin
+++ b/dnf/plugins/upgrade/upgrade.plugin
@@ -7,3 +7,5 @@ Authors = Igor Gnatenko <ignatenko@redhat.com>
 License = GPL-2.0+
 Copyright = Copyright © 2016 Igor Gnatenko
 X-Command-Syntax = upgrade [PACKAGE…]
+X-Alias-Name = update
+X-Alias-Description = Compatibility alias for the "upgrade" command


### PR DESCRIPTION
Compatibility with DNF.
DNF uses "upgrade". "update" is deprecated in DNF and is only supported for compatibility.

https://bugzilla.redhat.com/show_bug.cgi?id=1905471