### PR TITLE
Support for user confirmation and "assumeyes", "assumeno", "defaultyes"

### DIFF
--- a/dnf/dnf-utils.c
+++ b/dnf/dnf-utils.c
@@ -71,6 +71,72 @@ dnf_utils_add_transaction_packages (DnfContext *ctx,
 
 
 gboolean
+dnf_utils_conf_main_get_bool_opt (const gchar *name, enum DnfConfPriority *priority)
+{
+    g_autofree gchar *tmp = dnf_conf_main_get_option (name, priority, NULL);
+    return tmp != NULL && (*tmp == '1' || *tmp == 'y' || *tmp == 'Y');
+}
+
+
+gboolean
+dnf_utils_userconfirm (void)
+{
+  gboolean ret;
+  enum DnfConfPriority priority;
+
+  // "assumeno" takes precedence over "assumeyes"
+  if (dnf_utils_conf_main_get_bool_opt ("assumeno", &priority))
+    ret = FALSE;
+  else if (dnf_utils_conf_main_get_bool_opt ("assumeyes", &priority))
+    ret = TRUE;
+  else
+    {
+      gboolean defaultyes = dnf_utils_conf_main_get_bool_opt ("defaultyes", &priority);
+
+      const char *msg;
+      if (defaultyes)
+        msg = "Is this ok [Y/n]: ";
+      else
+        msg = "Is this ok [y/N]: ";
+
+      while (TRUE)
+        {
+          g_print ("%s", msg);
+
+          char choice = getchar ();
+          if (choice == '\n' || choice == '\r')
+            {
+              ret = defaultyes;
+              break;
+            }
+
+          char second = getchar ();
+          for (char ch = second; ch != '\n'; ch = getchar ())
+            ;
+
+          if (second == '\n' || second == '\r')
+            {
+              if (choice == 'y' || choice == 'Y')
+                {
+                  ret = TRUE;
+                  break;
+                }
+              if (choice == 'n' || choice == 'N')
+                {
+                  ret = FALSE;
+                  break;
+                }
+            }
+        }
+    }
+
+    if (!ret)
+      g_print ("Operation aborted.\n");
+
+    return ret;
+}
+
+gboolean
 dnf_utils_print_transaction (DnfContext *ctx)
 {
   g_autoptr(GPtrArray) pkgs = dnf_goal_get_packages (dnf_context_get_goal (ctx),

--- a/dnf/dnf-utils.h
+++ b/dnf/dnf-utils.h
@@ -25,5 +25,7 @@
 G_BEGIN_DECLS
 
 gboolean dnf_utils_print_transaction (DnfContext *ctx);
+gboolean dnf_utils_conf_main_get_bool_opt (const gchar *name, enum DnfConfPriority *priority);
+gboolean dnf_utils_userconfirm (void);
 
 G_END_DECLS

--- a/dnf/plugins/install/dnf-command-install.c
+++ b/dnf/plugins/install/dnf-command-install.c
@@ -84,6 +84,8 @@ dnf_command_install_run (DnfCommand      *cmd,
     return FALSE;
   if (!dnf_utils_print_transaction (ctx))
     return TRUE;
+  if (!dnf_utils_userconfirm ())
+    return FALSE;
   if (!dnf_context_run (ctx, NULL, error))
     return FALSE;
   g_print ("Complete.\n");

--- a/dnf/plugins/module_disable/dnf-command-module_disable.c
+++ b/dnf/plugins/module_disable/dnf-command-module_disable.c
@@ -85,6 +85,10 @@ dnf_command_module_disable_run (DnfCommand      *cmd,
     {
       return TRUE;
     }
+  if (!dnf_utils_userconfirm ())
+    {
+      return FALSE;
+    }
   if (!dnf_context_run (ctx, NULL, error))
     {
       return FALSE;

--- a/dnf/plugins/module_enable/dnf-command-module_enable.c
+++ b/dnf/plugins/module_enable/dnf-command-module_enable.c
@@ -89,6 +89,10 @@ dnf_command_module_enable_run (DnfCommand      *cmd,
     {
       return TRUE;
     }
+  if (!dnf_utils_userconfirm ())
+    {
+      return FALSE;
+    }
   if (!dnf_context_run (ctx, NULL, error))
     {
       return FALSE;

--- a/dnf/plugins/module_reset/dnf-command-module_reset.c
+++ b/dnf/plugins/module_reset/dnf-command-module_reset.c
@@ -89,6 +89,10 @@ dnf_command_module_reset_run (DnfCommand      *cmd,
     {
       return TRUE;
     }
+  if (!dnf_utils_userconfirm ())
+    {
+      return FALSE;
+    }
   if (!dnf_context_run (ctx, NULL, error))
     {
       return FALSE;

--- a/dnf/plugins/reinstall/dnf-command-reinstall.c
+++ b/dnf/plugins/reinstall/dnf-command-reinstall.c
@@ -160,7 +160,8 @@ dnf_command_reinstall_run (DnfCommand      *cmd,
 
   if (!dnf_utils_print_transaction (ctx))
     return TRUE;
-
+  if (!dnf_utils_userconfirm ())
+    return FALSE;
   if (!dnf_context_run (ctx, NULL, error))
     return FALSE;
 

--- a/dnf/plugins/remove/dnf-command-remove.c
+++ b/dnf/plugins/remove/dnf-command-remove.c
@@ -87,6 +87,8 @@ dnf_command_remove_run (DnfCommand      *cmd,
   if (!dnf_goal_depsolve (dnf_context_get_goal (ctx), DNF_ERASE, error))
     return FALSE;
   dnf_utils_print_transaction (ctx);
+  if (!dnf_utils_userconfirm ())
+    return FALSE;
   if (!dnf_context_run (ctx, NULL, error))
     return FALSE;
   g_print ("Complete.\n");

--- a/dnf/plugins/upgrade/dnf-command-upgrade.c
+++ b/dnf/plugins/upgrade/dnf-command-upgrade.c
@@ -81,6 +81,8 @@ dnf_command_upgrade_run (DnfCommand      *cmd,
     return FALSE;
   if (!dnf_utils_print_transaction (ctx))
     return TRUE;
+  if (!dnf_utils_userconfirm ())
+    return FALSE;
   if (!dnf_context_run (ctx, NULL, error))
     return FALSE;
   g_print ("Complete.\n");


### PR DESCRIPTION
Microdnf may ask the user to confirm the action. This question can be suppressed with the "assumeyes" and "assumeno" options.

We need to minimize the risk of breaking the existing containers. So, for backward compatibility reasons, the default value of "assumeyes" is TRUE (the user question is suppressed). The question can be activated by entering the line "assumeyes=0" in the global configuration file (dnf.conf).

Requires https://github.com/rpm-software-management/libdnf/pull/1109