### PR TITLE
[download] select one pkg to download for each NEVRA, support "--archlist=" argument

### DIFF
--- a/dnf/plugins/download/dnf-command-download.c
+++ b/dnf/plugins/download/dnf-command-download.c
@@ -310,8 +310,10 @@ dnf_command_download_run (DnfCommand      *cmd,
                           GError         **error)
 {
   g_auto(GStrv) opt_key = NULL;
+  g_autofree gchar *opt_archlist = NULL;
   gboolean opt_src = FALSE;
   const GOptionEntry opts[] = {
+    { "archlist", '\0', G_OPTION_FLAG_NONE, G_OPTION_ARG_STRING, &opt_archlist, "limit the query to packages of given architectures", "ARCH,..."},
     { "source", '\0', G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE, &opt_src, "download source packages", NULL },
     { G_OPTION_REMAINING, '\0', 0, G_OPTION_ARG_STRING_ARRAY, &opt_key, NULL, NULL },
     { NULL }
@@ -365,6 +367,12 @@ dnf_command_download_run (DnfCommand      *cmd,
   if (opt_src)
     {
       hy_query_filter (query, HY_PKG_ARCH, HY_EQ, "src");
+    }
+
+  if (opt_archlist)
+    {
+      g_auto(GStrv) archs_array = g_strsplit_set (opt_archlist, ", ", -1);
+      hy_query_filter_in (query, HY_PKG_ARCH, HY_EQ, (const char**)archs_array);
     }
 
   g_autoptr(GPtrArray) pkgs = hy_query_run (query);

--- a/dnf/plugins/download/dnf-command-download.c
+++ b/dnf/plugins/download/dnf-command-download.c
@@ -41,9 +41,12 @@ dnf_command_download_init (DnfCommandDownload *self)
 {
 }
 
-inline static gboolean str_ends_with (const gchar * buf, const gchar * val)
+inline static gboolean
+str_ends_with (const gchar * buf, const gchar * val)
 {
-  return strstr (buf, val) == (buf + (strlen (buf) - strlen (val)));
+  size_t buf_len = strlen (buf);
+  size_t val_len = strlen (val);
+  return buf_len >= val_len && memcmp (buf + buf_len - val_len, val, val_len) == 0;
 }
 
 static gboolean dnf_command_download_rewriterepotosrc (gchar * repo_buf)

--- a/dnf/plugins/download/download.plugin
+++ b/dnf/plugins/download/download.plugin
@@ -6,4 +6,4 @@ Description = Download packages
 Authors = Daniel Hams <daniel.hams@gmail.com>
 License = GPL-2.0+
 Copyright = Copyright © 2020-2021 Daniel Hams
-X-Command-Syntax = download [--source] PACKAGE [PACKAGE…]
+X-Command-Syntax = download [OPTION…] PACKAGE [PACKAGE…]


### PR DESCRIPTION
* select one pkg to download for each NEVRA
  There can be multiple packages with the same NEVRA in the repositories.  The code selects one (from the cheapest repository with the highest priority) package to download for each NEVRA.

* Support `--archlist=` argument
  Limits the query to packages of given architectures.