### PR TITLE
Add "makecache" command

### DIFF
--- a/dnf/CMakeLists.txt
+++ b/dnf/CMakeLists.txt
@@ -40,6 +40,11 @@ glib_compile_resources (DNF_COMMAND_DOWNLOAD plugins/download/dnf-command-downlo
                         INTERNAL)
 list (APPEND DNF_COMMAND_DOWNLOAD "plugins/download/dnf-command-download.c")
 
+glib_compile_resources (DNF_COMMAND_MAKECACHE plugins/makecache/dnf-command-makecache.gresource.xml
+                        C_PREFIX dnf_command_makecache
+                        INTERNAL)
+list (APPEND DNF_COMMAND_MAKECACHE "plugins/makecache/dnf-command-makecache.c")
+
 glib_compile_resources (DNF_COMMAND_MODULE_ENABLE plugins/module_enable/dnf-command-module_enable.gresource.xml
                         C_PREFIX dnf_command_module_enable
                         INTERNAL)
@@ -66,6 +71,7 @@ add_executable (microdnf dnf-main.c ${DNF_SRCS}
                 ${DNF_COMMAND_REPOQUERY}
                 ${DNF_COMMAND_CLEAN}
                 ${DNF_COMMAND_DOWNLOAD}
+                ${DNF_COMMAND_MAKECACHE}
                 ${DNF_COMMAND_MODULE_ENABLE}
                 ${DNF_COMMAND_MODULE_DISABLE}
                 ${DNF_COMMAND_MODULE_RESET})

--- a/dnf/meson.build
+++ b/dnf/meson.build
@@ -75,6 +75,15 @@ microdnf_srcs = [
   ),
   'plugins/download/dnf-command-download.c',
 
+  # makecache
+  gnome.compile_resources(
+    'dnf-makecache',
+    'plugins/makecache/dnf-command-makecache.gresource.xml',
+    c_name : 'dnf_command_makecache',
+    source_dir : 'plugins/makecache',
+  ),
+  'plugins/makecache/dnf-command-makecache.c',
+
   # module enable
   gnome.compile_resources(
     'dnf-module_enable',

--- a/dnf/plugins/makecache/dnf-command-makecache.c
+++ b/dnf/plugins/makecache/dnf-command-makecache.c
@@ -1,0 +1,95 @@
+/* dnf-command-makecache.c
+ *
+ * Copyright (C) 2021 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "dnf-command-makecache.h"
+
+struct _DnfCommandMakecache
+{
+  PeasExtensionBase parent_instance;
+};
+
+static void dnf_command_makecache_iface_init (DnfCommandInterface *iface);
+
+G_DEFINE_DYNAMIC_TYPE_EXTENDED (DnfCommandMakecache,
+                                dnf_command_makecache,
+                                PEAS_TYPE_EXTENSION_BASE,
+                                0,
+                                G_IMPLEMENT_INTERFACE (DNF_TYPE_COMMAND,
+                                                       dnf_command_makecache_iface_init))
+
+static void
+dnf_command_makecache_init (DnfCommandMakecache *self)
+{
+}
+
+static gboolean
+dnf_command_makecache_run (DnfCommand      *cmd,
+                           int              argc,
+                           char            *argv[],
+                           GOptionContext  *opt_ctx,
+                           DnfContext      *ctx,
+                           GError         **error)
+{
+  const GOptionEntry opts[] = {
+    { NULL }
+  };
+  g_option_context_add_main_entries (opt_ctx, opts, NULL);
+
+  if (!g_option_context_parse (opt_ctx, &argc, &argv, error))
+    return FALSE;
+
+  if (argc > 1)
+    {
+      g_set_error (error, G_OPTION_ERROR, G_OPTION_ERROR_UNKNOWN_OPTION, "Unknown argument %s", argv[1]);
+      return FALSE;
+    }
+
+  DnfState * state = dnf_context_get_state (ctx);
+  DnfContextSetupSackFlags sack_flags = DNF_CONTEXT_SETUP_SACK_FLAG_SKIP_RPMDB;
+  dnf_context_setup_sack_with_flags (ctx, state, sack_flags, error);
+
+  g_print ("Metadata cache created.\n");
+
+  return TRUE;
+}
+
+static void
+dnf_command_makecache_class_init (DnfCommandMakecacheClass *klass)
+{
+}
+
+static void
+dnf_command_makecache_iface_init (DnfCommandInterface *iface)
+{
+  iface->run = dnf_command_makecache_run;
+}
+
+static void
+dnf_command_makecache_class_finalize (DnfCommandMakecacheClass *klass)
+{
+}
+
+G_MODULE_EXPORT void
+dnf_command_makecache_register_types (PeasObjectModule *module)
+{
+  dnf_command_makecache_register_type (G_TYPE_MODULE (module));
+
+  peas_object_module_register_extension_type (module,
+                                              DNF_TYPE_COMMAND,
+                                              DNF_TYPE_COMMAND_MAKECACHE);
+}

--- a/dnf/plugins/makecache/dnf-command-makecache.gresource.xml
+++ b/dnf/plugins/makecache/dnf-command-makecache.gresource.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gresources>
+  <gresource prefix="/org/fedoraproject/dnf/plugins/makecache">
+    <file>makecache.plugin</file>
+  </gresource>
+</gresources>

--- a/dnf/plugins/makecache/dnf-command-makecache.h
+++ b/dnf/plugins/makecache/dnf-command-makecache.h
@@ -1,0 +1,31 @@
+/* dnf-command-makecache.h
+ *
+ * Copyright (C) 2021 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "dnf-command.h"
+#include <libpeas/peas.h>
+
+G_BEGIN_DECLS
+
+#define DNF_TYPE_COMMAND_MAKECACHE dnf_command_makecache_get_type ()
+G_DECLARE_FINAL_TYPE (DnfCommandMakecache, dnf_command_makecache, DNF, COMMAND_MAKECACHE, PeasExtensionBase)
+
+G_MODULE_EXPORT void dnf_command_makecache_register_types (PeasObjectModule *module);
+
+G_END_DECLS

--- a/dnf/plugins/makecache/makecache.plugin
+++ b/dnf/plugins/makecache/makecache.plugin
@@ -1,0 +1,9 @@
+[Plugin]
+Module = command_makecache
+Embedded = dnf_command_makecache_register_types
+Name = makecache
+Description = Generate the metadata cache
+Authors = Jaroslav Rohel <jrohel@redhat.com>
+License = GPL-2.0+
+Copyright = Copyright (C) 2021 Red Hat, Inc.
+X-Command-Syntax = makecache


### PR DESCRIPTION
Downloads and caches metadata for enabled repositories.
If "--refresh" argument is not used, tries to avoid downloading whenever possible (e.g. when the local metadata hasn't expired yet or when the metadata timestamp hasn't changed).

CI tests: https://github.com/rpm-software-management/ci-dnf-stack/pull/977