### PR TITLE
Add distro-sync subcommand

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ find_package (PkgConfig REQUIRED)
 pkg_check_modules (GLIB REQUIRED glib-2.0>=2.44.0)
 pkg_check_modules (GOBJECT REQUIRED gobject-2.0>=2.44.0)
 pkg_check_modules (PEAS REQUIRED libpeas-1.0>=1.20.0)
-pkg_check_modules (LIBDNF REQUIRED libdnf>=0.56.0)
+pkg_check_modules (LIBDNF REQUIRED libdnf>=0.62.0)
 pkg_check_modules (SCOLS REQUIRED smartcols)
 
 set (PKG_LIBDIR ${CMAKE_INSTALL_FULL_LIBDIR}/dnf)

--- a/dnf/CMakeLists.txt
+++ b/dnf/CMakeLists.txt
@@ -20,6 +20,11 @@ glib_compile_resources (DNF_COMMAND_UPGRADE plugins/upgrade/dnf-command-upgrade.
                         INTERNAL)
 list (APPEND DNF_COMMAND_UPGRADE "plugins/upgrade/dnf-command-upgrade.c")
 
+glib_compile_resources (DNF_COMMAND_DISTROSYNC plugins/distrosync/dnf-command-distrosync.gresource.xml
+                        C_PREFIX dnf_command_distrosync
+                        INTERNAL)
+list (APPEND DNF_COMMAND_DISTROSYNC "plugins/distrosync/dnf-command-distrosync.c")
+
 glib_compile_resources (DNF_COMMAND_REPOLIST plugins/repolist/dnf-command-repolist.gresource.xml
                         C_PREFIX dnf_command_repolist
                         INTERNAL)
@@ -67,6 +72,7 @@ add_executable (microdnf dnf-main.c ${DNF_SRCS}
                 ${DNF_COMMAND_REINSTALL}
                 ${DNF_COMMAND_REMOVE}
                 ${DNF_COMMAND_UPGRADE}
+                ${DNF_COMMAND_DISTROSYNC}
                 ${DNF_COMMAND_REPOLIST}
                 ${DNF_COMMAND_REPOQUERY}
                 ${DNF_COMMAND_CLEAN}

--- a/dnf/meson.build
+++ b/dnf/meson.build
@@ -39,6 +39,15 @@ microdnf_srcs = [
   ),
   'plugins/upgrade/dnf-command-upgrade.c',
 
+  # distro-sync
+  gnome.compile_resources(
+    'dnf-distrosync',
+    'plugins/distrosync/dnf-command-distrosync.gresource.xml',
+    c_name : 'dnf_command_distrosync',
+    source_dir : 'plugins/distrosync',
+  ),
+  'plugins/upgrade/dnf-command-distrosync.c',
+
   # repolist
   gnome.compile_resources(
     'dnf-repolist',

--- a/dnf/plugins/distrosync/distrosync.plugin
+++ b/dnf/plugins/distrosync/distrosync.plugin
@@ -1,0 +1,11 @@
+[Plugin]
+Module = command_distro-sync
+Embedded = dnf_command_distrosync_register_types
+Name = distro-sync
+Description = Upgrade/downgrade packages to match versions in repositories
+Authors = Neal Gompa <ngompa13@gmail.com>
+License = GPL-2.0+
+Copyright = Copyright © 2021 Neal Gompa
+X-Command-Syntax = distro-sync [PACKAGE…]
+X-Alias-Name = distribution-synchronization
+X-Alias-Description = Compatibility alias for the "distro-sync" command

--- a/dnf/plugins/distrosync/dnf-command-distrosync.c
+++ b/dnf/plugins/distrosync/dnf-command-distrosync.c
@@ -1,0 +1,117 @@
+/* dnf-command-distrosync.c
+ *
+ * Copyright © 2021 Neal Gompa <ngompa13@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "dnf-command-distrosync.h"
+#include "dnf-utils.h"
+
+struct _DnfCommandDistroSync
+{
+  PeasExtensionBase parent_instance;
+};
+
+static void dnf_command_distrosync_iface_init (DnfCommandInterface *iface);
+
+G_DEFINE_DYNAMIC_TYPE_EXTENDED (DnfCommandDistroSync,
+                                dnf_command_distrosync,
+                                PEAS_TYPE_EXTENSION_BASE,
+                                0,
+                                G_IMPLEMENT_INTERFACE (DNF_TYPE_COMMAND,
+                                                       dnf_command_distrosync_iface_init))
+
+static void
+dnf_command_distrosync_init (DnfCommandDistroSync *self)
+{
+}
+
+static gboolean
+dnf_command_distrosync_run (DnfCommand      *cmd,
+                         int              argc,
+                         char            *argv[],
+                         GOptionContext  *opt_ctx,
+                         DnfContext      *ctx,
+                         GError         **error)
+{
+  g_auto(GStrv) pkgs = NULL;
+  const GOptionEntry opts[] = {
+    { G_OPTION_REMAINING, '\0', 0, G_OPTION_ARG_STRING_ARRAY, &pkgs, NULL, NULL },
+    { NULL }
+  };
+  g_option_context_add_main_entries (opt_ctx, opts, NULL);
+
+  if (!g_option_context_parse (opt_ctx, &argc, &argv, error))
+    return FALSE;
+
+  if (pkgs == NULL)
+    {
+      if (!dnf_context_distrosync_all (ctx, error))
+        return FALSE;
+    }
+  else
+    {
+      /* Sync each package */
+      for (GStrv pkg = pkgs; *pkg != NULL; pkg++)
+        {
+          if (!dnf_context_distrosync (ctx, *pkg, error))
+            return FALSE;
+        }
+    }
+  DnfGoalActions flags = 0;
+  if (dnf_context_get_best())
+    {
+      flags |= DNF_FORCE_BEST;
+    }
+  if (!dnf_context_get_install_weak_deps ())
+    flags |= DNF_IGNORE_WEAK_DEPS;
+  if (!dnf_goal_depsolve (dnf_context_get_goal (ctx), flags, error))
+    return FALSE;
+  if (!dnf_utils_print_transaction (ctx))
+    return TRUE;
+  if (!dnf_utils_userconfirm ())
+    return FALSE;
+  if (!dnf_context_run (ctx, NULL, error))
+    return FALSE;
+  g_print ("Complete.\n");
+
+  return TRUE;
+}
+
+static void
+dnf_command_distrosync_class_init (DnfCommandDistroSyncClass *klass)
+{
+}
+
+static void
+dnf_command_distrosync_iface_init (DnfCommandInterface *iface)
+{
+  iface->run = dnf_command_distrosync_run;
+}
+
+static void
+dnf_command_distrosync_class_finalize (DnfCommandDistroSyncClass *klass)
+{
+}
+
+G_MODULE_EXPORT void
+dnf_command_distrosync_register_types (PeasObjectModule *module)
+{
+  dnf_command_distrosync_register_type (G_TYPE_MODULE (module));
+
+  peas_object_module_register_extension_type (module,
+                                              DNF_TYPE_COMMAND,
+                                              DNF_TYPE_COMMAND_DISTROSYNC);
+}

--- a/dnf/plugins/distrosync/dnf-command-distrosync.gresource.xml
+++ b/dnf/plugins/distrosync/dnf-command-distrosync.gresource.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gresources>
+  <gresource prefix="/org/fedoraproject/dnf/plugins/distrosync">
+    <file>distrosync.plugin</file>
+  </gresource>
+</gresources>

--- a/dnf/plugins/distrosync/dnf-command-distrosync.h
+++ b/dnf/plugins/distrosync/dnf-command-distrosync.h
@@ -1,0 +1,31 @@
+/* dnf-command-distrosync.h
+ *
+ * Copyright © 2021 Neal Gompa <ngompa13@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "dnf-command.h"
+#include <libpeas/peas.h>
+
+G_BEGIN_DECLS
+
+#define DNF_TYPE_COMMAND_DISTROSYNC dnf_command_distrosync_get_type ()
+G_DECLARE_FINAL_TYPE (DnfCommandDistroSync, dnf_command_distrosync, DNF, COMMAND_DISTROSYNC, PeasExtensionBase)
+
+G_MODULE_EXPORT void dnf_command_distrosync_register_types (PeasObjectModule *module);
+
+G_END_DECLS

--- a/meson.build
+++ b/meson.build
@@ -32,7 +32,7 @@ gnome = import('gnome')
 glib = dependency('glib-2.0', version : '>=2.44.0')
 gobject = dependency('gobject-2.0', version : '>=2.44.0')
 libpeas = dependency('libpeas-1.0', version : '>=1.20.0')
-libdnf = dependency('libdnf', version : '>=0.56.0')
+libdnf = dependency('libdnf', version : '>=0.62.0')
 scols = dependency('smartcols')
 
 pkg_libdir = join_paths(get_option('prefix'), get_option('libdir'), 'dnf')

--- a/microdnf.spec
+++ b/microdnf.spec
@@ -1,4 +1,4 @@
-%global libdnf_version 0.56.0
+%global libdnf_version 0.62.0
 
 Name:           microdnf
 Version:        3.7.1


### PR DESCRIPTION
This provides the minimum functionality to mimic `dnf distro-sync`.
A libdnf minimum version bump is required due to new APIs being used.

Requires: https://github.com/rpm-software-management/libdnf/pull/1189