### PR TITLE
Better naming of the cache directory

### DIFF
--- a/dnf/dnf-main.c
+++ b/dnf/dnf-main.c
@@ -272,7 +272,7 @@ context_new (void)
 {
   DnfContext *ctx = dnf_context_new ();
 
-#define CACHEDIR "/var/cache/yum"
+#define CACHEDIR "/var/cache/microdnf"
   dnf_context_set_cache_dir (ctx, CACHEDIR"/metadata");
   dnf_context_set_solv_dir (ctx, CACHEDIR"/solv");
   dnf_context_set_lock_dir (ctx, CACHEDIR"/lock");

--- a/microdnf.spec
+++ b/microdnf.spec
@@ -42,6 +42,7 @@ minimal environment possible so you can build up to exactly what you need.
 
 %install
 %meson_install
+mkdir -p %{buildroot}/var/cache/microdnf
 
 %check
 %meson_test
@@ -51,5 +52,6 @@ minimal environment possible so you can build up to exactly what you need.
 %doc README.md
 %{_mandir}/man8/microdnf.8*
 %{_bindir}/%{name}
+%dir /var/cache/microdnf
 
 %changelog


### PR DESCRIPTION
This is microdnf, not yum.
Normal dnf uses /var/cache/dnf. It is not a good idea to reuse it.
But there is no need to use /var/cache/yum, at least in ROSA where this package did not exist before.

Naming cache directory as "microdnf" allows to own it properly in the RPM package.

[ this pull request is a suggestion, I am not sure that you will want to change location on the fly, breaking compatibility ]