### PR TITLE
Support "--setopt=ignorearch=0/1"

### DIFF
--- a/dnf/dnf-main.c
+++ b/dnf/dnf-main.c
@@ -33,6 +33,7 @@ typedef enum { ARG_DEFAULT, ARG_FALSE, ARG_TRUE } BoolArgs;
 static BoolArgs opt_install_weak_deps = ARG_DEFAULT;
 static BoolArgs opt_allow_vendor_change = ARG_DEFAULT;
 static BoolArgs opt_keepcache = ARG_DEFAULT;
+static BoolArgs opt_ignorearch = ARG_DEFAULT;
 static gboolean opt_no = FALSE;
 static gboolean opt_yes = FALSE;
 static gboolean opt_nodocs = FALSE;
@@ -215,6 +216,20 @@ process_global_option (const gchar  *option_name,
               ret = FALSE;
             }
         }
+        else if (strcmp (setopt[0], "ignorearch") == 0)
+          {
+            const char *setopt_val = setopt[1];
+            if (setopt_val[0] == '1' && setopt_val[1] == '\0')
+              opt_ignorearch = ARG_TRUE;
+            else if (setopt_val[0] == '0' && setopt_val[1] == '\0')
+              opt_ignorearch = ARG_FALSE;
+            else
+              {
+                local_error = g_error_new (G_OPTION_ERROR, G_OPTION_ERROR_BAD_VALUE,
+                                           "Invalid boolean value \"%s\" in: %s", setopt[1], value);
+                ret = FALSE;
+              }
+          }
       else if (strcmp (setopt[0], "reposdir") == 0)
         {
           reposdir_used = TRUE;
@@ -263,7 +278,7 @@ static const GOptionEntry global_opts[] = {
   { "refresh", '\0', G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE, &opt_refresh, "Set metadata as expired before running the command", NULL },
   { "releasever", '\0', G_OPTION_FLAG_NONE, G_OPTION_ARG_CALLBACK, process_global_option, "Override the value of $releasever in config and repo files", "RELEASEVER" },
   { "setopt", '\0', G_OPTION_FLAG_NONE, G_OPTION_ARG_CALLBACK, process_global_option,
-    "Override a configuration option (install_weak_deps=0/1, allow_vendor_change=0/1, keepcache=0/1, module_platform_id=<name:stream>, cachedir=<path>, reposdir=<path1>,<path2>,..., tsflags=nodocs/test, varsdir=<path1>,<path2>,..., repo_id.option_name=<value>)", "<option>=<value>" },
+    "Override a configuration option (install_weak_deps=0/1, allow_vendor_change=0/1, keepcache=0/1, ignorearch=0/1, module_platform_id=<name:stream>, cachedir=<path>, reposdir=<path1>,<path2>,..., tsflags=nodocs/test, varsdir=<path1>,<path2>,..., repo_id.option_name=<value>)", "<option>=<value>" },
   { NULL }
 };
 
@@ -569,6 +584,11 @@ main (int   argc,
         dnf_context_set_keep_cache (ctx, TRUE);
       else if (opt_keepcache == ARG_FALSE)
         dnf_context_set_keep_cache (ctx, FALSE);
+
+      if (opt_ignorearch == ARG_TRUE)
+        dnf_context_set_ignore_arch (TRUE);
+      else if (opt_ignorearch == ARG_FALSE)
+        dnf_context_set_ignore_arch (FALSE);
 
       if (opt_best && opt_nobest)
         {


### PR DESCRIPTION
Once https://github.com/rpm-software-management/libdnf/pull/1309 gets merged and a new tag gets cut, this will allow us to supply the ignorearch option. I will still have to bump the minimum required version of libdnf.

This will fix https://github.com/rpm-software-management/microdnf/issues/114