### PR TITLE
Check return value from sack setup

### DIFF
--- a/dnf/plugins/download/dnf-command-download.c
+++ b/dnf/plugins/download/dnf-command-download.c
@@ -429,7 +429,9 @@ dnf_command_download_run (DnfCommand      *cmd,
   DnfState * state = dnf_context_get_state (ctx);
   DnfContextSetupSackFlags sack_flags = !opt_resolve || opt_alldeps ? DNF_CONTEXT_SETUP_SACK_FLAG_SKIP_RPMDB
                                                                     : DNF_CONTEXT_SETUP_SACK_FLAG_NONE;
-  dnf_context_setup_sack_with_flags (ctx, state, sack_flags, error);
+  if (!dnf_context_setup_sack_with_flags (ctx, state, sack_flags, error)) {
+      return FALSE;
+  }
 
   hy_autoquery HyQuery query = get_packages_query (ctx, opt_key, opt_src, opt_archlist);
 

--- a/dnf/plugins/leaves/dnf-command-leaves.c
+++ b/dnf/plugins/leaves/dnf-command-leaves.c
@@ -327,10 +327,13 @@ dnf_command_leaves_run (DnfCommand      *cmd,
 
   // only look at installed packages
   disable_available_repos (ctx);
-  dnf_context_setup_sack_with_flags (ctx,
-                                     dnf_context_get_state (ctx),
-                                     DNF_CONTEXT_SETUP_SACK_FLAG_NONE,
-                                     error);
+  if (!dnf_context_setup_sack_with_flags (ctx,
+                                          dnf_context_get_state (ctx),
+                                          DNF_CONTEXT_SETUP_SACK_FLAG_NONE,
+                                          error)) {
+
+      return FALSE;
+  }
 
   // get a sorted array of all installed packages
   hy_autoquery HyQuery query = hy_query_create (dnf_context_get_sack (ctx));

--- a/dnf/plugins/makecache/dnf-command-makecache.c
+++ b/dnf/plugins/makecache/dnf-command-makecache.c
@@ -61,7 +61,9 @@ dnf_command_makecache_run (DnfCommand      *cmd,
 
   DnfState * state = dnf_context_get_state (ctx);
   DnfContextSetupSackFlags sack_flags = DNF_CONTEXT_SETUP_SACK_FLAG_SKIP_RPMDB;
-  dnf_context_setup_sack_with_flags (ctx, state, sack_flags, error);
+  if (!dnf_context_setup_sack_with_flags (ctx, state, sack_flags, error)) {
+      return FALSE;
+  }
 
   g_print ("Metadata cache created.\n");
 

--- a/dnf/plugins/reinstall/dnf-command-reinstall.c
+++ b/dnf/plugins/reinstall/dnf-command-reinstall.c
@@ -140,7 +140,9 @@ dnf_command_reinstall_run (DnfCommand      *cmd,
     }
 
   DnfState * state = dnf_context_get_state (ctx);
-  dnf_context_setup_sack_with_flags (ctx, state, DNF_CONTEXT_SETUP_SACK_FLAG_NONE, error);
+  if (!dnf_context_setup_sack_with_flags (ctx, state, DNF_CONTEXT_SETUP_SACK_FLAG_NONE, error)) {
+      return FALSE;
+  }
 
   for (GStrv pkg = pkgs; *pkg != NULL; pkg++)
     {

--- a/dnf/plugins/repoquery/dnf-command-repoquery.c
+++ b/dnf/plugins/repoquery/dnf-command-repoquery.c
@@ -141,7 +141,9 @@ dnf_command_repoquery_run (DnfCommand     *cmd,
   DnfState * state = dnf_context_get_state (ctx);
   DnfContextSetupSackFlags sack_flags = opt_available ? DNF_CONTEXT_SETUP_SACK_FLAG_SKIP_RPMDB
                                                       : DNF_CONTEXT_SETUP_SACK_FLAG_NONE;
-  dnf_context_setup_sack_with_flags (ctx, state, sack_flags, error);
+  if (!dnf_context_setup_sack_with_flags (ctx, state, sack_flags, error)) {
+      return FALSE;
+  }
   DnfSack *sack = dnf_context_get_sack (ctx);
 
   hy_autoquery HyQuery query = hy_query_create (sack);


### PR DESCRIPTION
We need to know if the sack is setup correctly.
Skipping the check can manifest for example in:
- Not working `skip_if_unavailable` repo option
- Segfault in reinstall command because goal is not setup in sack

Tests: https://github.com/rpm-software-management/ci-dnf-stack/pull/1145