### PR TITLE
Prepare for F39: require libdnf5, not dnf-data

### DIFF
--- a/microdnf.spec
+++ b/microdnf.spec
@@ -21,7 +21,7 @@ BuildRequires:  help2man
 Requires:       libdnf%{?_isa} >= %{libdnf_version}
 %if 0%{?rhel} > 8 || 0%{?fedora}
 # Ensure DNF package manager configuration skeleton is installed
-Requires:       dnf-data
+Requires:       /etc/dnf/dnf.conf
 %endif
 
 %description


### PR DESCRIPTION
/etc/dnf/dnf.conf is now owned by libdnf5, not dnf-data.

Part of https://github.com/rpm-software-management/dnf5/pull/469.