### PR TITLE
reinstall: fix regression: error when no packages to reinstall

### DIFF
--- a/dnf/plugins/reinstall/dnf-command-reinstall.c
+++ b/dnf/plugins/reinstall/dnf-command-reinstall.c
@@ -157,6 +157,15 @@ dnf_command_reinstall_run (DnfCommand      *cmd,
         return FALSE;
     }
 
+  if (!hy_goal_has_actions(dnf_context_get_goal(ctx), DNF_DOWNGRADE | DNF_INSTALL | DNF_UPGRADE))
+  {
+      g_set_error_literal(error,
+                          DNF_ERROR,
+                          DNF_ERROR_NO_PACKAGES_TO_UPDATE,
+                          "No packages marked for reinstall");
+      return FALSE;
+  }
+
   DnfGoalActions flags = DNF_INSTALL;
   if (!dnf_context_get_install_weak_deps ())
     flags |= DNF_IGNORE_WEAK_DEPS;  


### PR DESCRIPTION
Fixes two regressions in ci-dnf-stack tests caused by https://github.com/rpm-software-management/libdnf/pull/1739:

```
dnf/microdnf/reinstall3.feature:16  Reinstall an RPM that is not available
dnf/microdnf/reinstall-not-installed.feature:9  Reinstall an RPM that is available, but not installed
```

Before libdnf@5937a9022081ad731347af65392b439d1deed657, when no matches could be found for any argument of `microdnf reinstall`, microdnf would call `dnf_goal_depsolve`, see that `hy_goal_req_length(goal) == 0`, and exit with `DNF_ERROR_NO_PACKAGES_TO_UPDATE` "The transaction was empty".

But as of libdnf@5937a9022081ad731347af65392b439d1deed657, extra information is added to the goal to mark protected packages as user-installed, which causes the goal length to be greater than zero, and the error message is skipped. So before this microdnf commit, microdnf would instead exit with code 0 and "Nothing to do", which is a breaking change.

With this microdnf commit, microdnf throws an error similar to DNF when there is nothing to reinstall, and exits with code 1.